### PR TITLE
Don't scan NULL log_file

### DIFF
--- a/kerneloops.c
+++ b/kerneloops.c
@@ -188,7 +188,8 @@ int main(int argc, char**argv)
 	/* during boot... don't go too fast and slow the system down */
 	if (!testmode)
 		sleep(10);
-	scan_filename(log_file, 1);
+	if (log_file)
+		scan_filename(log_file, 1);
 
 	if (argc > 2 && strstr(argv[1], "--file"))
 		scan_filename(argv[2], 1);


### PR DESCRIPTION
log_file is NULL when running on a system without /etc/kerneloops.conf.

For example on a system where kerneloops is built and the tests run:

.==31758== Syscall param stat(file_name) points to unaddressable byte(s)
==31758==    at 0x5913EE5: _xstat (xstat.c:35)
==31758==    by 0x10B300: stat (stat.h:454)
==31758==    by 0x10B300: scan_filename (dmesg.c:384)
==31758==    by 0x1099E4: main (kerneloops.c:191)
==31758==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==31758==