### PR TITLE
dbus: remove deprecated at_console statement

### DIFF
--- a/kerneloops.dbus
+++ b/kerneloops.dbus
@@ -15,7 +15,7 @@
     <allow own="org.kerneloops.submit.url"/>
   </policy>
 
-  <policy at_console="true">
+  <policy context="default">
     <allow send_destination="org.kerneloops.submit"/>
     <allow send_destination="org.kerneloops.submit.ping"/>
     <allow receive_sender="org.kerneloops.submit"/>


### PR DESCRIPTION
As described in [0], this likely did not have the intended effect, so
simply remove it. The change in behavior is that up until this patch
it would be possible for any non-system user to potentially gain
access to kerneloops' dbus interface. Now this is extended to also allow
any system user.

[0]: <https://www.spinics.net/lists/linux-bluetooth/msg75267.html>

Signed-off-by: Tom Gundersen <teg@jklm.no>
CC: David Herrmann <dh.herrmann@gmail.com>