### PR TITLE
Drop not working ExecStartPre option from kerneloops.service

### DIFF
--- a/kerneloops.service
+++ b/kerneloops.service
@@ -5,7 +5,6 @@ After=remote-fs.target nss-lookup.target network-online.target time-sync.target
 [Service]
 EnvironmentFile=-/etc/default/kerneloops
 Type=forking
-ExecStartPre=/usr/sbin/kerneloops --test
 ExecStart=/usr/sbin/kerneloops $DAEMON_ARGS
 
 [Install]


### PR DESCRIPTION
kerneloops does not handle --test option

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=921210